### PR TITLE
Preliminary support for newer kernelcaches

### DIFF
--- a/src/a64.h
+++ b/src/a64.h
@@ -845,7 +845,9 @@ static inline bool is_eor(eor_t *eor)
 
 static inline bool is_bti(bti_t *bti)
 {
-    return bti->op == 0b11010101000000110010;
+    return bti->op == 0b11010101000000110010 &&
+           bti->CRm == 0b0100 &&
+           (bti->op2 & 0b00111111) == 0b011111;
 }
 
 static inline bool is_ands_reg(and_reg_t *and)

--- a/src/a64.h
+++ b/src/a64.h
@@ -328,6 +328,13 @@ typedef struct
              op  : 21;
 } bra_t;
 
+typedef struct
+{
+    uint32_t op2    :  8,
+             CRm    :  4,
+             op     : 20;
+} bti_t;
+
 typedef uint32_t nop_t;
 typedef uint32_t ret_t;
 #pragma pack()
@@ -834,6 +841,11 @@ static inline bool is_orr(orr_t *orr)
 static inline bool is_eor(eor_t *eor)
 {
     return eor->op == 0b10100100;
+}
+
+static inline bool is_bti(bti_t *bti)
+{
+    return bti->op == 0b11010101000000110010;
 }
 
 // and/orr/eor - holy clusterfuck

--- a/src/a64.h
+++ b/src/a64.h
@@ -848,6 +848,16 @@ static inline bool is_bti(bti_t *bti)
     return bti->op == 0b11010101000000110010;
 }
 
+static inline bool is_ands_reg(and_reg_t *and)
+{
+    return and->op == 0b1101010 && and->N == 0;
+}
+
+static inline bool is_ands(and_t *and)
+{
+    return and->op == 0b11100100;
+}
+
 // and/orr/eor - holy clusterfuck
 
 extern uint64_t DecodeBitMasks(uint8_t N, uint8_t imms, uint8_t immr, uint8_t bits);

--- a/src/a64emu.c
+++ b/src/a64emu.c
@@ -1303,7 +1303,7 @@ emu_ret_t a64_emulate(void *kernel, kptr_t kbase, fixup_kind_t fixupKind, a64_st
                     ERR("Bug in a64_emulate (case and/orr/eor) at " ADDR, addr);
                     exit(-1);
                 }
-                if(orr->Rd != 31)
+                if(!want_nzcv || orr->Rd != 31)
                 {
                     state->x[orr->Rd] = Rd;
                     state->valid |= 1 << orr->Rd;

--- a/src/main.c
+++ b/src/main.c
@@ -1497,7 +1497,7 @@ int main(int argc, const char **argv)
                                         }
                                         else
                                         {
-                                            if((void*)bti >= kernel && is_bti(bti))
+                                            if((void*)bti >= kernel && is_bti(bti) && (bti->op2 & 0xc0) == 0x40)
                                             {
                                                 refloc -= 4;
                                             }
@@ -1826,7 +1826,7 @@ int main(int argc, const char **argv)
                                     if(meta->addr == addr)
                                     {
                                         bti_t* bti = (bti_t*)(adr - 1);
-                                        if((void*)bti >= kernel && is_bti(bti))
+                                        if((void*)bti >= kernel && is_bti(bti) && (bti->op2 & 0xc0) == 0x40)
                                         {
                                             func -= 4;
                                         }

--- a/src/main.c
+++ b/src/main.c
@@ -3037,7 +3037,6 @@ int main(int argc, const char **argv)
                     }
                     if(!iaddr)
                     {
-                        WRN("No kmod_info for %s", name);
                         continue;
                     }
                     kmod_info_t *kmod = addr2ptr(kernel, iaddr);

--- a/src/main.c
+++ b/src/main.c
@@ -1825,6 +1825,11 @@ int main(int argc, const char **argv)
                                     metaclass_t *meta = &metas.val[i];
                                     if(meta->addr == addr)
                                     {
+                                        bti_t* bti = (bti_t*)(adr - 1);
+                                        if((void*)bti >= kernel && is_bti(bti))
+                                        {
+                                            func -= 4;
+                                        }
                                         DBG("Got func " ADDR " referencing MetaClass %s", func, meta->name);
                                         //candidates.idx = 0;
                                         if(!meta->vtab)

--- a/src/main.c
+++ b/src/main.c
@@ -3336,6 +3336,10 @@ int main(int argc, const char **argv)
                             continue;
                         }
                         DBG("Kext %s at " ADDR, str, kext_base);
+                        if(kext_base == 0x7fffffffffffffff)
+                        {
+                            continue;
+                        }
                         mach_hdr_t *hdr2 = addr2ptr(kernel, kext_base);
                         if(!hdr2)
                         {

--- a/src/main.c
+++ b/src/main.c
@@ -3077,16 +3077,15 @@ int main(int argc, const char **argv)
                     }
                 }
             }
+            haveBundles = true;
             for(size_t i = 0; i < metas.idx; ++i)
             {
                 metaclass_t *meta = &metas.val[i];
                 if(!meta->bundle)
                 {
-                    ERR("Metaclass without a bundle: %s (" ADDR ")", meta->name, meta->callsite);
-                    return -1;
+                    haveBundles = false;
                 }
             }
-            haveBundles = true;
         }
         else if(hdr->filetype == MH_EXECUTE)
         {
@@ -3250,7 +3249,7 @@ int main(int argc, const char **argv)
                     }
                 }
             }
-            if(hdr->filetype == MH_EXECUTE)
+            if(hdr->filetype == MH_EXECUTE || hdr->filetype == MH_FILESET)
             {
                 if(!prelink_info) prelink_info = get_prelink_info(hdr);
 
@@ -3365,6 +3364,15 @@ int main(int argc, const char **argv)
                         }
                     }
                 }
+            }
+        }
+        for(size_t i = 0; i < metas.idx; ++i)
+        {
+            metaclass_t *meta = &metas.val[i];
+            if(!meta->bundle)
+            {
+                ERR("Metaclass without a bundle: %s (" ADDR ")", meta->name, meta->callsite);
+                return -1;
             }
         }
         if(filt_bundle)

--- a/src/main.c
+++ b/src/main.c
@@ -1462,6 +1462,7 @@ int main(int argc, const char **argv)
                         {
                             STEP_MEM(uint32_t, mem, (uintptr_t)kernel + seg->fileoff, seg->filesize, 3)
                             {
+                                bti_t     *bti = (bti_t*    )(mem - 1);
                                 adr_t     *adr = (adr_t*    )(mem + 0);
                                 add_imm_t *add = (add_imm_t*)(mem + 1);
                                 ret_t     *ret = (ret_t*    )(mem + 2);
@@ -1496,6 +1497,10 @@ int main(int argc, const char **argv)
                                         }
                                         else
                                         {
+                                            if((void*)bti >= kernel && is_bti(bti))
+                                            {
+                                                refloc -= 4;
+                                            }
                                             DBG("OSMetaClass::getMetaClass: " ADDR, refloc);
                                             OSObjectGetMetaClass = refloc;
                                         }
@@ -1533,9 +1538,7 @@ int main(int argc, const char **argv)
             for(size_t i = 0; is_part_of_vtab(kernel, kbase, fixupKind, locreloc.val, locreloc.idx, exrelocA, nexreloc, ovtab, OSObjectVtab, i); ++i)
             {
                 bool bind = false;
-                // DEBUG
-                kptr_t VtabMethod = kuntag(kbase, fixupKind, ovtab[i], &bind, NULL, NULL, NULL);
-                if(VtabMethod == OSObjectGetMetaClass || VtabMethod == OSObjectGetMetaClass - 4)
+                if(kuntag(kbase, fixupKind, ovtab[i], &bind, NULL, NULL, NULL) == OSObjectGetMetaClass)
                 {
                     if(bind)
                     {

--- a/src/main.c
+++ b/src/main.c
@@ -1533,7 +1533,9 @@ int main(int argc, const char **argv)
             for(size_t i = 0; is_part_of_vtab(kernel, kbase, fixupKind, locreloc.val, locreloc.idx, exrelocA, nexreloc, ovtab, OSObjectVtab, i); ++i)
             {
                 bool bind = false;
-                if(kuntag(kbase, fixupKind, ovtab[i], &bind, NULL, NULL, NULL) == OSObjectGetMetaClass)
+                // DEBUG
+                kptr_t VtabMethod = kuntag(kbase, fixupKind, ovtab[i], &bind, NULL, NULL, NULL);
+                if(VtabMethod == OSObjectGetMetaClass || VtabMethod == OSObjectGetMetaClass - 4)
                 {
                     if(bind)
                     {
@@ -2070,6 +2072,10 @@ int main(int argc, const char **argv)
                                             else if((state.valid & 0xff) == 0xf && (state.wide & 0xf) == 0x9) // hell do I know
                                             {
                                                 allocsz = state.x[1];
+                                            }
+                                            else if((state.valid & 0xff) == 0x3 && (state.wide & 0x1ff) == 0x1) // muirey: hell do I know
+                                            {
+                                                allocsz = state.x[(state.valid & 0x100) ? 8 : 1];
                                             }
                                             else
                                             {


### PR DESCRIPTION
Changes:
- Emulator support for ANDS and BTI instructions
- Add timeout to emulation (ApplePPM::ApplePPM() contains a while loop that can loop forever with best-effort emulation)
- Consider that the first instruction of OSMetaClass::getMetaClass is not always ADR now (can be BTI instead)
- Add a new case to allocsz calculations

Left to do:
- Still not all instructions implemented (STRB, MADD, ...)
- Probably lots more

An interesting note is that abstract classes don't seem to have vtables anymore (I don't know how new this change is, but they do on the recent macOS kernelcaches I've analyzed)